### PR TITLE
Use working api

### DIFF
--- a/walletgenie_plugins/walletgenie_plugins.py
+++ b/walletgenie_plugins/walletgenie_plugins.py
@@ -513,7 +513,7 @@ class BasePluginCoin(BasePlugin):
 			self.output('requests module not found, netki lookup disabled -- enable it by installing requests: `pip install requests`')
 			return None
 		
-		url = 'https://netki.com/api/wallet_lookup/'
+		url = 'https://pubapi.netki.com/api/wallet_lookup/'
 		headers = {
 			'Host': 'netki.com', 'User-Agent': 'WalletGenie netki integration',
 			'Content-type': 'application/json'


### PR DESCRIPTION
Netki changed walletnames to walletnames.com, so the api no longer works at https://netki.com.  This update fixes the url